### PR TITLE
Changed step syntax to #step

### DIFF
--- a/lessons/meta-tut/steps.md
+++ b/lessons/meta-tut/steps.md
@@ -1,2 +1,2 @@
-# { step: 1 }
+#step
 ### It works!

--- a/lessons/polymorphism/steps.md
+++ b/lessons/polymorphism/steps.md
@@ -1,31 +1,31 @@
-# { step: 1, hide: [e] }
+#step hide: [e], append: true
 ## Inheritance at compile time in Java
 In order for your Java code to compile, it has to pass the compiler's type checks. First, let's look at how this is checked when a variable is assigned via the `=` operator.
 
 
-# { step: 2, spotlight: [a] }
+#step { spotlight: [a] }
 Keeping in mind the types given, will this statement compile?
 
 
-# { step: 3, pass: [a] }
+#step { pass: [a] }
 Whenever something in Java is assigned to a variable, the variable's type must match the thing it is being assigned to.
 
 This statement is valid, because the type `String` given to the variable matches the type `String` given to the string literal.
 
 
-# { step: 4a, spotlight: [b, c] }
+#step { spotlight: [b, c] }
 What about this line? `Object` isn't the same as `String`. How does the compiler handle this?
 
 
-# { step: 4b, pass: [b, c] }
+#step { pass: [b, c] }
 The compiler has no issue with this, because `String` inherits from `Object`. In other words, a `String` is an `Object`, and so the statement is valid.
 
 
-# { step: 4c, spotlight: [b, d]}
+#step { spotlight: [b, d]}
 How will the compiler process this line, keeping in mind that `strAsObj` is defined as `"string b"`?
 
 
-# { step: 5, fail: [b, d] }
+#step { fail: [b, d] }
 This line fails! The compiler doesn't care that `strAsObj` has a value of `"string b"`.
 
 We gave `strAsObj` the static type `Object`, and when checking types at compile time **only the static types are considered**. So the compiler compares `String` to `Object`, and finds that `Object` does not inherit from `String`.

--- a/lessons/python-test/steps.md
+++ b/lessons/python-test/steps.md
@@ -1,2 +1,2 @@
-# {step: 1, pass: [a]}
+#step {pass: [a]}
 This is step 1!


### PR DESCRIPTION
No more indicies. 

```
# {step: 1}
```

becomes

```
#step {}
```

or more simply, since in this case there are no actions being performed:

```
#step
```
