### PR TITLE
Added routing urls for lesson select

### DIFF
--- a/lib/app_component.dart
+++ b/lib/app_component.dart
@@ -1,26 +1,23 @@
-import 'package:angular2/core.dart' show Component, OnInit;
+import 'package:angular2/core.dart' show Component;
+import 'package:angular2/router.dart';
 import 'code_guide_component.dart';
-import 'step_context_service.dart';
+
+@RouteConfig(const [
+  const Route(
+      path: '/lesson/:lesson_name',
+      name: 'Lesson',
+      component: CodeGuideComponent
+  ),
+  const Redirect(
+      path: '/',
+      redirectTo: const ['Lesson', const {'lesson_name': 'polymorphism'}]
+  )
+])
 
 @Component(
     selector: 'my-app',
     templateUrl: 'html/app_component.html',
     styleUrls: const ['css/app_component.css'],
-    directives: const [CodeGuideComponent]
+    directives: const [CodeGuideComponent, ROUTER_DIRECTIVES]
 )
-class AppComponent implements OnInit {
-  StepContextService stepContextService;
-  String lessonName = 'polymorphism';
-
-  AppComponent(this.stepContextService);
-
-  void userSelectLesson() {
-    stepContextService.selectLesson('static/lesson-$lessonName.json')
-        .catchError((dynamic err) =>
-          print('ERROR: $err'));
-  }
-
-  void ngOnInit() {
-    userSelectLesson();
-  }
-}
+class AppComponent {}

--- a/lib/code_guide_component.dart
+++ b/lib/code_guide_component.dart
@@ -1,13 +1,26 @@
-import 'package:angular2/core.dart' show Component;
+import 'package:angular2/core.dart' show Component, OnInit;
 
 import 'code_explanation_component.dart';
 import 'code_viewer_component.dart';
+import 'package:angular2/router.dart';
 import 'package:code_steps/step_action.dart';
+import 'package:code_steps/step_context_service.dart';
 
 @Component(
-  selector: 'code-guide',
-  templateUrl: 'html/code_guide_component.html',
-  styleUrls: const ['css/code_guide_component.css'],
-  directives: const [CodeExplanationComponent, CodeViewerComponent]
-)
-class CodeGuideComponent {}
+    selector: 'code-guide',
+    templateUrl: 'html/code_guide_component.html',
+    styleUrls: const ['css/code_guide_component.css'],
+    directives: const [CodeExplanationComponent, CodeViewerComponent])
+class CodeGuideComponent implements OnInit {
+  StepContextService stepContextService;
+  RouteParams _routeParams;
+  CodeGuideComponent(this.stepContextService, this._routeParams);
+
+  ngOnInit() {
+    String lesson_name = _routeParams.get('lesson_name');
+    stepContextService
+        .selectLesson(
+            'static/lesson-$lesson_name.json', _routeParams.get('step'))
+        .catchError((dynamic err) => print('ERROR: $err'));
+  }
+}

--- a/lib/code_viewer_component.dart
+++ b/lib/code_viewer_component.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'package:angular2/core.dart';
 import 'package:code_steps/step_context_service.dart';
 import 'package:code_steps/step_data.dart';

--- a/lib/css/app_component.css
+++ b/lib/css/app_component.css
@@ -2,19 +2,16 @@
     font-size: 1.2rem;
 }
 
-code-guide {
+:host code-guide {
     margin: 50px auto 10px;
+    display:block;
+    width: 100%;
 }
 
-nav.lesson-steps-nav {
-    margin: 10px auto 0;
-    display: table;
+@media (max-width: 992px) {
+    :host code-guide {
+        margin-top: 0 !important;
+    }
 }
 
-nav.lesson-steps-nav button {
-    margin: 0 5px;
-}
 
-#lesson-select-poc {
-    font-size: medium;
-}

--- a/lib/css/code_guide_component.css
+++ b/lib/css/code_guide_component.css
@@ -1,29 +1,36 @@
-:host {
+:host .code-card {
     display: block;
     height: 500px;
     box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.48);
 }
 
-:host .row {
+.code-card .row {
     height: 100%;
 }
 
-@media (min-width: 1200px) {
-    :host {
-        max-width: 1200px;
+@media (min-width: 992px) {
+    .code-card {
+        max-width: 992px;
     }
 }
 
 @media (max-width: 991px) {
-    :host {
+    .code-card {
         max-width: 100%;
-        margin-top: 0 !important;
     }
-
 }
 
 @media (max-width: 543px) {
     code-explanation, code-viewer {
         height: 50%
     }
+}
+
+nav.lesson-steps-nav {
+    margin: 10px auto 0;
+    display: table;
+}
+
+nav.lesson-steps-nav button {
+    margin: 0 5px;
 }

--- a/lib/html/app_component.html
+++ b/lib/html/app_component.html
@@ -1,18 +1,2 @@
-<code-guide class="container-fluid">
-</code-guide>
+<router-outlet></router-outlet>
 
-<nav class="lesson-steps-nav">
-    <button class="btn btn-primary"
-            (click)="stepContextService.gotoPrevious()"
-            [disabled]="!stepContextService.hasPrevious()">Previous</button>
-    <input [(ngModel)]="stepContextService.stepIndex" type="range" min="0"
-           [max]="stepContextService.length - 1" title="step-progress">
-    <button class="btn btn-primary"
-            (click)="stepContextService.gotoNext()"
-            [disabled]="!stepContextService.hasNext()">Next</button>
-</nav>
-<!-- should be moved to component -->
-    <form id="lesson-select-poc" (ngSubmit)="userSelectLesson()">
-        <div>Select a lesson</div>
-        <input type="text" [(ngModel)]="lessonName" placeholder="Enter lesson name">
-    </form>

--- a/lib/html/code_guide_component.html
+++ b/lib/html/code_guide_component.html
@@ -1,4 +1,16 @@
-<div class="row">
-    <code-explanation class="col-sm-6"></code-explanation>
-    <code-viewer class="col-sm-6"></code-viewer>
+<div class="code-card container-fluid">
+    <div class="row">
+        <code-explanation class="col-sm-6"></code-explanation>
+        <code-viewer class="col-sm-6"></code-viewer>
+    </div>
 </div>
+<nav class="lesson-steps-nav">
+    <button class="btn btn-primary"
+            (click)="stepContextService.gotoPrevious()"
+            [disabled]="!stepContextService.hasPrevious()">Previous</button>
+    <input [(ngModel)]="stepContextService.stepIndex" type="range" min="0"
+           [max]="stepContextService.length - 1" title="step-progress">
+    <button class="btn btn-primary"
+            (click)="stepContextService.gotoNext()"
+            [disabled]="!stepContextService.hasNext()">Next</button>
+</nav>

--- a/lib/step_context_service.dart
+++ b/lib/step_context_service.dart
@@ -13,13 +13,13 @@ class StepContextService extends Injectable with ChangeNotifier {
   StepContextService(
       LessonLoader this._lessonLoader, this._stepActionsProvider);
 
-  Future selectLesson(url) {
+  Future selectLesson(url, [initial_step_index]) {
     return _lessonLoader.loadData(url).then((HashMap lessonData) {
       loadedSteps =
           StepData.toStepData(_stepActionsProvider, lessonData['steps']);
       StepData.interpolateSteps(_stepActionsProvider, loadedSteps);
       loadedCode = lessonData['code'];
-      _stepIndex = notifyPropertyChange(#currStep, _stepIndex, 0);
+      stepIndex = initial_step_index ?? 0;
     });
   }
 
@@ -36,8 +36,10 @@ class StepContextService extends Injectable with ChangeNotifier {
   @reflectable
   String get loadedCode => _loadedCode;
   @reflectable
-  set loadedCode(String val) =>
-      _loadedCode = notifyPropertyChange(#loadedCode, _loadedCode, val);
+  set loadedCode(String val) {
+    _loadedCode = null; // hack to force refresh the code even if equal
+    _loadedCode = notifyPropertyChange(#loadedCode, _loadedCode, val);
+  }
 
   void gotoNext() {
     _stepIndex = notifyPropertyChange(#changeStep, _stepIndex, _stepIndex + 1);
@@ -47,8 +49,7 @@ class StepContextService extends Injectable with ChangeNotifier {
       _loadedSteps != null && _stepIndex < _loadedSteps.length - 1;
 
   void gotoPrevious() {
-    _stepIndex =
-        notifyPropertyChange(#changeStep, _stepIndex, _stepIndex - 1);
+    _stepIndex = notifyPropertyChange(#changeStep, _stepIndex, _stepIndex - 1);
   }
 
   bool hasPrevious() => _loadedSteps != null && _stepIndex > 0;
@@ -60,25 +61,19 @@ class StepContextService extends Injectable with ChangeNotifier {
   /**
    * Sets the step index to a desired value. If a string is passed in, it is converted to an integer automatically
    */
-  set stepIndex(new_currStep) {
-    if (new_currStep is String) new_currStep = int.parse(new_currStep);
-    _stepIndex = notifyPropertyChange(
-        #changeStep,
-        _stepIndex,
-        new_currStep);
+  set stepIndex(new_stepIndex) {
+    if (new_stepIndex is String) new_stepIndex = int.parse(new_stepIndex);
+    if (new_stepIndex >= 0 && new_stepIndex < length) {
+      _stepIndex = notifyPropertyChange(#changeStep, _stepIndex, new_stepIndex);
+    } else {
+      print('ERROR: Index $new_stepIndex out of bounds.');
+    }
   }
 
   /**
    * Returns the number of steps, or zero if no steps are loaded
    */
   int get length => loadedSteps?.length ?? 0;
-
-  StepData get previousStep => (loadedSteps == null || _stepIndex - 1 < 0)
-      ? null
-      : loadedSteps[_stepIndex - 1];
-
-  StepData get nextStep => (loadedSteps == null ||
-      _stepIndex >= _loadedSteps.length) ? null : loadedSteps[_stepIndex + 1];
 
   String get currCodeHtml => loadedCode;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>code_steps</title>
 
+    <base href=".">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css"
           integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">

--- a/web/main.dart
+++ b/web/main.dart
@@ -1,14 +1,22 @@
 // Copyright (c) 2016, <your name>. All rights reserved. Use of this source code
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
+import 'package:angular2/core.dart';
 import 'package:angular2/platform/browser.dart';
 
+import 'package:angular2/platform/common.dart';
+import 'package:angular2/router.dart';
 import 'package:code_steps/app_component.dart';
 import 'package:code_steps/lesson_loader.dart';
 import 'package:code_steps/step_context_service_provider.dart';
-import 'package:code_steps/step_action.dart';
 import 'package:code_steps/step_actions_provider.dart';
 
 main() {
-  bootstrap(AppComponent, [LessonLoader, StepActionsProvider, stepContextServiceProvider]);
+  bootstrap(AppComponent, [
+    LessonLoader,
+    StepActionsProvider,
+    stepContextServiceProvider,
+    ROUTER_PROVIDERS,
+    provide(LocationStrategy, useClass: HashLocationStrategy)
+  ]);
 }


### PR DESCRIPTION
For example, the url `/lesson/:lesson_name` now takes you to the lesson with a given name `:lesson_name`. Generates the lesson json url by taking the parameter and adding it to the string `'/web/static/lesson-$lesson_name.json'`

Removed the ugly lesson select bar from the bottom of the page.

The url `/` now redirects to `/lesson/polymorphism` as an example.
