### PR TITLE
Adds page with list of lessons

### DIFF
--- a/lib/app_component.dart
+++ b/lib/app_component.dart
@@ -1,6 +1,7 @@
-import 'package:angular2/core.dart' show Component;
+import 'package:angular2/core.dart';
 import 'package:angular2/router.dart';
 import 'code_guide_component.dart';
+import 'package:code_steps/lesson_list_component.dart';
 
 @RouteConfig(const [
   const Route(
@@ -8,9 +9,14 @@ import 'code_guide_component.dart';
       name: 'Lesson',
       component: CodeGuideComponent
   ),
+  const Route(
+      path: '/lessons',
+      name: 'Lesson List',
+      component: LessonListComponent
+  ),
   const Redirect(
       path: '/',
-      redirectTo: const ['Lesson', const {'lesson_name': 'polymorphism'}]
+      redirectTo: const ['Lesson List']
   )
 ])
 

--- a/lib/code_viewer_component.dart
+++ b/lib/code_viewer_component.dart
@@ -1,4 +1,3 @@
-import 'dart:developer';
 import 'package:angular2/core.dart';
 import 'package:code_steps/step_context_service.dart';
 import 'package:code_steps/step_data.dart';

--- a/lib/html/lesson_list_component.html
+++ b/lib/html/lesson_list_component.html
@@ -1,0 +1,8 @@
+<h2>Lesson List</h2>
+<ul>
+    <li *ngFor="let lesson of lessons">
+        <a [routerLink]="['Lesson', {'lesson_name': lesson['name']}]">{{lesson['name']}} ({{lesson['length']}} steps)</a>
+    </li>
+</ul>
+
+<i>Generated from <code>make lessons</code></i>

--- a/lib/lesson_list_component.dart
+++ b/lib/lesson_list_component.dart
@@ -1,0 +1,22 @@
+import 'dart:collection';
+import 'package:angular2/core.dart';
+import 'package:angular2/router.dart';
+import 'package:code_steps/lesson_loader.dart';
+
+@Component(
+    selector: 'lesson-list',
+    templateUrl: 'html/lesson_list_component.html',
+    directives: const [ROUTER_DIRECTIVES]
+)
+class LessonListComponent implements OnInit {
+  LessonLoader lessonLoader;
+  List lessons;
+  LessonListComponent(this.lessonLoader);
+
+  @override
+  ngOnInit() {
+    lessonLoader.loadData('static/lessons.json').then((HashMap lessons_json) {
+      this.lessons = lessons_json['lessons'];
+    });
+  }
+}


### PR DESCRIPTION
`/lessons` loads a page with links to each lesson that was generated using the `make lessons` command.

Updated ruby script to output a `lessons.json` file with overview data for each lesson
